### PR TITLE
Bump version number -> npm publish extended API

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name" : "kexec", 
-    "version" : "0.1.1", 
+    "version" : "0.1.2", 
     "description" : "Replace your Node.js process with another process. Like Ruby exec.", 
     "homepage" : [
         "https://github.com/jprichardson/node-kexec"


### PR DESCRIPTION
Suggest bumping the version number and publishing the extended API.

I could merge this myself, but I can't publish it.
