### PR TITLE
Move pangyp into dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
     "install": "pangyp configure build"
   },
   "devDependencies": {
-    "mocha": "^2.1.0",
-    "pangyp": "^2.0.1"
+    "mocha": "^2.1.0"
   },
-  "dependencies": {}
+  "dependencies": {
+    "pangyp": "^2.0.1"
+  }
 }


### PR DESCRIPTION
Should fix #14.

Shouldn't need to install `pangyp` globally in order to be able to install `kexec`.