### PR TITLE
Set correct macros for node v0.12

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,8 +4,8 @@
       'target_name': 'kexec',
       'sources': [ 'src/kexec.cc' ],
       'defines': [
-        '<!@(node -v |grep "v0.11" > /dev/null && echo "__NODE_V0_11__" || echo "__NOT_NODE_V0_11__")',
-        '<!@(command -v iojs > /dev/null && echo "__NODE_V0_11__" || echo "__NOT_NODE_V0_11__")'
+        '<!@(node -v |grep "v0.1[12]" > /dev/null && echo "__NODE_GTE_V0_11__" || echo "__NODE_LT_V0_11__")',
+        '<!@(command -v iojs > /dev/null && echo "__NODE_GTE_V0_11__" || echo "__NODE_LT_V0_11__")'
       ]
     }
   ]

--- a/src/kexec.cc
+++ b/src/kexec.cc
@@ -4,7 +4,7 @@
 #include <cstdio>
 #include <stdlib.h>
 #include <string.h>
-#ifdef __NODE_V0_11__
+#ifdef __NODE_GTE_V0_11__
 #include <fcntl.h>
 #endif
 
@@ -35,7 +35,7 @@ static int do_exec(char *argv[])
         return execvp(argv[0], argv);
 }
 
-#ifdef __NODE_V0_11__
+#ifdef __NODE_GTE_V0_11__
 static void kexec(const FunctionCallbackInfo<Value>& args) {
     Isolate* isolate = Isolate::GetCurrent();
     HandleScope scope(isolate);
@@ -71,7 +71,7 @@ static Handle<Value> kexec(const Arguments& args) {
 
         int err = do_exec(argv);
 
-#ifdef __NODE_V0_11__
+#ifdef __NODE_GTE_V0_11__
         Local<Number> num = Number::New(isolate, err);
         args.GetReturnValue().Set(num);
 #else
@@ -95,7 +95,7 @@ static Handle<Value> kexec(const Arguments& args) {
         argv[0] = *v8str;
         argv[argv_length-1] = NULL;
         for (int i = 0; i < argc; i++) {
-#ifdef __NODE_V0_11__
+#ifdef __NODE_GTE_V0_11__
             String::Utf8Value arg(argv_handle->Get(Integer::New(isolate, i))->ToString());
 #else
             String::Utf8Value arg(argv_handle->Get(Integer::New(i))->ToString());
@@ -111,7 +111,7 @@ static Handle<Value> kexec(const Arguments& args) {
             free(argv[i+1]);
         delete [] argv;
 
-#ifdef __NODE_V0_11__
+#ifdef __NODE_GTE_V0_11__
         Local<Number> num = Number::New(isolate, err);
         args.GetReturnValue().Set(num);
 #else
@@ -120,7 +120,7 @@ static Handle<Value> kexec(const Arguments& args) {
 #endif
     }
 
-#ifdef __NODE_V0_11__
+#ifdef __NODE_GTE_V0_11__
     isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "kexec: invalid arguments")));
     args.GetReturnValue().Set(Undefined(isolate));
 #else


### PR DESCRIPTION
This fixes compilation problems with the new stable version of node.