### PR TITLE
rejigger for node v4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 .PHONY: build test demo demovp demovp-pids demos
 
 build:
-	./node_modules/.bin/pangyp clean
-	./node_modules/.bin/pangyp configure
-	./node_modules/.bin/pangyp build
+	./node_modules/.bin/node-gyp clean
+	./node_modules/.bin/node-gyp configure
+	./node_modules/.bin/node-gyp build
 
 test:
 	$(MAKE) build

--- a/binding.gyp
+++ b/binding.gyp
@@ -4,8 +4,10 @@
       'target_name': 'kexec',
       'sources': [ 'src/kexec.cc' ],
       'defines': [
-        '<!@(node -v |grep "v0.1[12]" > /dev/null && echo "__NODE_GTE_V0_11__" || echo "__NODE_LT_V0_11__")',
-        '<!@(command -v iojs > /dev/null && echo "__NODE_GTE_V0_11__" || echo "__NODE_LT_V0_11__")'
+        '<!@(node -v |grep "v4" > /dev/null && echo "__NODE_V4__" || true)',
+        '<!@(node -v |grep "v0.1[12]" > /dev/null && echo "__NODE_V0_11_OR_12__" || true)',
+        '<!@(command -v iojs > /dev/null && echo "__NODE_V0_11_OR_12__" || true)',
+        '<!@(node -v |grep "v0.10" > /dev/null && echo "__NODE_V0_10__" || true)',
       ]
     }
   ]

--- a/package.json
+++ b/package.json
@@ -14,22 +14,18 @@
     "kexec"
   ],
   "author": "JP Richardson <jprichardson@gmail.com>",
-  "licenses": [
-    {
-      "type": "MIT"
-    }
-  ],
+  "license": "MIT",
   "main": "./index",
   "engines": {
     "node": ">=0.10"
   },
   "scripts": {
-    "install": "pangyp configure build"
+    "install": "node-gyp configure build"
   },
   "devDependencies": {
-    "mocha": "^2.1.0"
+    "mocha": "^2.3.3"
   },
   "dependencies": {
-    "pangyp": "^2.0.1"
+    "node-gyp": "^3.0.3"
   }
 }

--- a/src/kexec.cc
+++ b/src/kexec.cc
@@ -4,7 +4,7 @@
 #include <cstdio>
 #include <stdlib.h>
 #include <string.h>
-#ifdef __NODE_GTE_V0_11__
+#if defined(__NODE_V0_11_OR_12__) || defined(__NODE_V4__)
 #include <fcntl.h>
 #endif
 
@@ -35,13 +35,13 @@ static int do_exec(char *argv[])
         return execvp(argv[0], argv);
 }
 
-#ifdef __NODE_GTE_V0_11__
+#if defined(__NODE_V0_10__)
+static Handle<Value> kexec(const Arguments& args) {
+    HandleScope scope;
+#else
 static void kexec(const FunctionCallbackInfo<Value>& args) {
     Isolate* isolate = Isolate::GetCurrent();
     HandleScope scope(isolate);
-#else
-static Handle<Value> kexec(const Arguments& args) {
-    HandleScope scope;
 #endif
 
 
@@ -71,12 +71,12 @@ static Handle<Value> kexec(const Arguments& args) {
 
         int err = do_exec(argv);
 
-#ifdef __NODE_GTE_V0_11__
-        Local<Number> num = Number::New(isolate, err);
-        args.GetReturnValue().Set(num);
-#else
+#if defined(__NODE_V0_10__)
         Local<Number> num = Number::New(err);
         return scope.Close(num/*Undefined()*/);
+#else
+        Local<Number> num = Number::New(isolate, err);
+        args.GetReturnValue().Set(num);
 #endif
     }
 
@@ -95,10 +95,10 @@ static Handle<Value> kexec(const Arguments& args) {
         argv[0] = *v8str;
         argv[argv_length-1] = NULL;
         for (int i = 0; i < argc; i++) {
-#ifdef __NODE_GTE_V0_11__
-            String::Utf8Value arg(argv_handle->Get(Integer::New(isolate, i))->ToString());
+#if defined(__NODE_V0_10__)
+          String::Utf8Value arg(argv_handle->Get(Integer::New(i))->ToString());
 #else
-            String::Utf8Value arg(argv_handle->Get(Integer::New(i))->ToString());
+          String::Utf8Value arg(argv_handle->Get(Integer::New(isolate, i))->ToString());
 #endif
             argv[i+1] = strdup(*arg);
         }
@@ -111,21 +111,21 @@ static Handle<Value> kexec(const Arguments& args) {
             free(argv[i+1]);
         delete [] argv;
 
-#ifdef __NODE_GTE_V0_11__
-        Local<Number> num = Number::New(isolate, err);
-        args.GetReturnValue().Set(num);
-#else
+#if defined(__NODE_V0_10__)
         Local<Number> num = Number::New(err);
         return scope.Close(num/*Undefined()*/);
+#else
+        Local<Number> num = Number::New(isolate, err);
+        args.GetReturnValue().Set(num);
 #endif
     }
 
-#ifdef __NODE_GTE_V0_11__
-    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "kexec: invalid arguments")));
-    args.GetReturnValue().Set(Undefined(isolate));
-#else
+#if defined(__NODE_V0_10__)
     ThrowException(Exception::TypeError(String::New("kexec: invalid arguments")));
     return scope.Close(Undefined());
+#else
+    isolate->ThrowException(Exception::TypeError(String::NewFromUtf8(isolate, "kexec: invalid arguments")));
+    args.GetReturnValue().Set(Undefined(isolate));
 #endif
 }
 


### PR DESCRIPTION
tested to work on node v0.10, v0.11, v0.12, and v4

drops iojs support as pangyp is deprecated and doesn't work with v4

fixes jprichardson/node-kexec#20