### PR TITLE
add ci files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+language: node_js
+node_js:
+  - "4.2"
+  - "4.1"
+  - "4.0"
+  - "0.12"
+  - "0.11"
+  - "0.10"
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+    - ubuntu-toolchain-r-test
+    packages:
+    - gcc-4.8
+    - g++-4.8

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,9 @@
+machine:
+  node:
+    version: 4.1.0
+machine:
+  pre:
+    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.6 10
+    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.6 10
+    - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.9 20
+    - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.9 20


### PR DESCRIPTION
CI wasn't working on Travis and CircleCI because both use g++ < 4.8 by default, which is not compatible with compiling Node v4 addons.

Please use the included CI file as templates in your own repo.

Brought up in jprichardson/node-kexec#20