### PR TITLE
Removed dependency on node-gyp

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,7 @@
   "engines": {
     "node": ">=0.10"
   },
-  "scripts": {
-    "install": "node-gyp configure build"
-  },
   "devDependencies": {
     "mocha": "^2.3.3"
-  },
-  "dependencies": {
-    "node-gyp": "^3.0.3"
   }
 }


### PR DESCRIPTION
Use the one bundled with npm. Also, npm itself compiles it on install when if finds a bindings.gyp file