### PR TITLE
Remove references to local node-gyp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 .PHONY: build test demo demovp demovp-pids demos
 
 build:
-	./node_modules/.bin/node-gyp clean
-	./node_modules/.bin/node-gyp configure
-	./node_modules/.bin/node-gyp build
+	node-gyp clean
+	node-gyp configure
+	node-gyp build
 
 test:
 	$(MAKE) build


### PR DESCRIPTION
Remove references to local `.bin/node-gyp` now that the dependency has been removed.