### PR TITLE
explicitly find npm's node-gyp in make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 
 .PHONY: build test demo demovp demovp-pids demos
 
+REALPATH := $(shell which realpath || echo "readlink -f")
+NPM_PATH := $(shell $(REALPATH) `which npm`)
+NPM_DIR := $(shell dirname $(NPM_PATH))
+NPM_NODE_GYP := $(NPM_DIR)/node-gyp-bin/node-gyp
+
 build:
-	node-gyp clean
-	node-gyp configure
-	node-gyp build
+	$(NPM_NODE_GYP) clean
+	$(NPM_NODE_GYP) configure
+	$(NPM_NODE_GYP) build
 
 test:
 	$(MAKE) build


### PR DESCRIPTION
`make build` was unable to find npm's node-gyp. Though this did not affect `node-kexec` users, it did cause failures development and testing environments (CircleCI was failing, etc).

This fix explicitly finds npm's node-gyp on both OSX and Linux resolving the issue.