### PR TITLE
add support for node >= v5.x

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,10 +4,10 @@
       'target_name': 'kexec',
       'sources': [ 'src/kexec.cc' ],
       'defines': [
-        '<!@(node -v |grep "v4" > /dev/null && echo "__NODE_V4__" || true)',
-        '<!@(node -v |grep "v0.1[12]" > /dev/null && echo "__NODE_V0_11_OR_12__" || true)',
+        '<!@(node -v |grep "v[^0]" > /dev/null && echo "__NODE_GE_V4__" || true)',
+        '<!@(node -v |grep "v0\.1[12]" > /dev/null && echo "__NODE_V0_11_OR_12__" || true)',
         '<!@(command -v iojs > /dev/null && echo "__NODE_V0_11_OR_12__" || true)',
-        '<!@(node -v |grep "v0.10" > /dev/null && echo "__NODE_V0_10__" || true)',
+        '<!@(node -v |grep "v0\.10" > /dev/null && echo "__NODE_V0_10__" || true)',
       ]
     }
   ]

--- a/src/kexec.cc
+++ b/src/kexec.cc
@@ -4,7 +4,7 @@
 #include <cstdio>
 #include <stdlib.h>
 #include <string.h>
-#if defined(__NODE_V0_11_OR_12__) || defined(__NODE_V4__)
+#if defined(__NODE_V0_11_OR_12__) || defined(__NODE_GE_V4__)
 #include <fcntl.h>
 #endif
 


### PR DESCRIPTION
Forward compatible with node v6.x &c. and tested on:

* iojs-v3.3.1
* v0.10.40
* v0.11.16
* v0.12.8
* v4.2.2
* v5.0.0
* v5.1.0