### PR TITLE
Remove unnecessary handle scope

### DIFF
--- a/src/kexec.cc
+++ b/src/kexec.cc
@@ -42,8 +42,6 @@ static int do_exec(char *argv[])
 }
 
 NAN_METHOD(kexec) {
-    Nan::HandleScope scope;
-
     /*
      * Steve Blott: 17 Jan, 2014
      *              Temporary comment by way of explanation...


### PR DESCRIPTION
Handle scopes are only necessary when using the V8 API independent of JS land.
